### PR TITLE
feat: добавил https в проект через certabot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,5 +122,7 @@ HEALTH_API_PORT=8001
 # Required in production: Docker Compose will refuse to start Grafana without this value.
 # Set a strong password here; it is applied once on the first container start.
 GRAFANA_ADMIN_PASSWORD=change_me_before_deploy
-PUBLIC_DOMAIN=localhost
-NGINX_PORT=8080
+# Production HTTPS observability domain. DNS must point this name to the deploy host.
+PUBLIC_DOMAIN=monitoring.probochka-corp.ru
+# Production reverse-proxy HTTP port. The production compose also publishes 443 for HTTPS.
+NGINX_PORT=80

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -109,9 +109,78 @@ That means:
 - Redis stays internal to the Docker network
 - the bot does not reserve any host port
 - the health API process itself stays internal and is exposed only through the reverse proxy when the `health` profile is enabled
-- the current production entrypoint is the `nginx` service, which publishes `${NGINX_PORT:-8080}:80`
+- the current production entrypoint is the `nginx` service, which publishes `${NGINX_PORT:-80}:80` and `443:443`
 
 Production services also use strict Docker log rotation limits to reduce disk growth on shared servers.
+
+## HTTPS Observability Endpoint
+
+Production observability is served through Nginx on:
+
+- `https://monitoring.probochka-corp.ru/grafana/`
+- `https://monitoring.probochka-corp.ru/health/`
+
+The expected DNS record is:
+
+```text
+monitoring.probochka-corp.ru A 31.163.204.186
+```
+
+The TLS certificate is managed by Certbot on the host, not by the application container. Certificate files must stay on the server under `/etc/letsencrypt` and must never be copied into the repository, logs, fixtures, or GitHub Secrets.
+
+Before deploying the TLS-enabled Nginx config for the first time, issue the initial certificate on the server while port `80` is free:
+
+```bash
+sudo certbot certonly --standalone \
+  -d monitoring.probochka-corp.ru \
+  --agree-tos \
+  -m <ops-email> \
+  --no-eff-email
+sudo mkdir -p /var/www/certbot
+```
+
+After the first deploy, switch renewal to the mounted webroot and verify renewal:
+
+```bash
+sudo certbot certonly --webroot \
+  -w /var/www/certbot \
+  -d monitoring.probochka-corp.ru \
+  --cert-name monitoring.probochka-corp.ru \
+  --force-renewal
+sudo systemctl enable --now certbot.timer
+sudo certbot renew --dry-run
+```
+
+Install a Certbot deploy hook so renewed certificates are picked up by the running Nginx container:
+
+```bash
+sudo tee /etc/letsencrypt/renewal-hooks/deploy/reload-pybot-nginx.sh >/dev/null <<'SH'
+#!/bin/sh
+set -eu
+cd /home/ilya/pybot
+docker compose -f docker-compose.prod.yml exec -T nginx nginx -s reload
+SH
+sudo chmod 0755 /etc/letsencrypt/renewal-hooks/deploy/reload-pybot-nginx.sh
+```
+
+The deployed production `.env` should include:
+
+```env
+PUBLIC_DOMAIN=monitoring.probochka-corp.ru
+NGINX_PORT=80
+HEALTH_API_ENABLED=true
+```
+
+Post-deploy smoke checks for the HTTPS entrypoint:
+
+```bash
+docker compose -f docker-compose.prod.yml exec nginx nginx -t
+curl -I http://monitoring.probochka-corp.ru/health/
+curl -I https://monitoring.probochka-corp.ru/health/
+curl -I https://monitoring.probochka-corp.ru/grafana/
+```
+
+Expected results: HTTP redirects to HTTPS, `/health/` returns `200`, Grafana returns a successful response or redirect under `/grafana/`.
 
 ## Safety for Shared Servers
 
@@ -178,8 +247,10 @@ At minimum, set:
 - `REDIS_URL=redis://redis:6379/0`
 - `AUTO_SEED_DB=false`
 - `LOG_LEVEL=INFO`
-- `HEALTH_API_ENABLED=false`
+- `HEALTH_API_ENABLED=true`
 - `TASKIQ_WORKERS=1`
+- `PUBLIC_DOMAIN=monitoring.probochka-corp.ru`
+- `NGINX_PORT=80`
 - `LEADERBOARD_WEEKLY_RETRY_ENABLED=true`
 - `LEADERBOARD_WEEKLY_RETRY_MAX_RETRIES=3`
 - `LEADERBOARD_WEEKLY_RETRY_DELAY_S=30`

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -114,11 +114,8 @@ services:
     restart: unless-stopped
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD must be set}
-      # TODO: Replace 'localhost' with the real domain name when one is configured.
-      # Currently routes Grafana sub-path correctly for IP-only access.
-      # When a domain is added, update to: http://your-domain.com/grafana/
-      - GF_SERVER_DOMAIN=${PUBLIC_DOMAIN:-localhost}
-      - GF_SERVER_ROOT_URL=http://${PUBLIC_DOMAIN:-localhost}:${NGINX_PORT:-8080}/grafana/
+      - GF_SERVER_DOMAIN=${PUBLIC_DOMAIN:-monitoring.probochka-corp.ru}
+      - GF_SERVER_ROOT_URL=https://${PUBLIC_DOMAIN:-monitoring.probochka-corp.ru}/grafana/
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
     volumes:
       - grafana_data:/var/lib/grafana
@@ -135,9 +132,12 @@ services:
     image: nginx:alpine
     restart: unless-stopped
     ports:
-      - "${NGINX_PORT:-8080}:80"
+      - "${NGINX_PORT:-80}:80"
+      - "443:443"
     volumes:
       - ./observability/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - /var/www/certbot:/var/www/certbot:ro
     depends_on:
       - grafana
     logging:

--- a/observability/nginx/nginx.conf
+++ b/observability/nginx/nginx.conf
@@ -3,22 +3,46 @@ events {}
 http {
     server {
         listen 80;
-        server_name _;
+        server_name monitoring.probochka-corp.ru;
 
-        absolute_redirect off;
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        location / {
+            return 308 https://$host$request_uri;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name monitoring.probochka-corp.ru;
+
+        ssl_certificate /etc/letsencrypt/live/monitoring.probochka-corp.ru/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/monitoring.probochka-corp.ru/privkey.pem;
 
         # Health API
         location /health/ {
             proxy_pass http://health:8001/;
             proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Scheme $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         # Grafana
         location /grafana/ {
             proxy_pass http://grafana:3000;
             proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+            return 404;
         }
     }
 }


### PR DESCRIPTION
## Тип изменений

- [x] Новая функциональность (New Feature)
- [ ] Исправление ошибки (Bug Fix)
- [ ] Рефакторинг (Refactoring)
- [ ] Оптимизация (Performance)
- [x] Обновление документации (Docs)
- [x] Настройка окружения/CI (Chore)

## Описание изменений

Добавлен production HTTPS endpoint для observability на домене `monitoring.probochka-corp.ru`.

Что изменено:

- `docker-compose.prod.yml`
  - nginx теперь публикует `80:80` и `443:443`;
  - добавлены read-only mounts для `/etc/letsencrypt` и `/var/www/certbot`;
  - Grafana настроена на `https://${PUBLIC_DOMAIN}/grafana/`;
  - сохранён `GF_SERVER_SERVE_FROM_SUB_PATH=true`.

- `observability/nginx/nginx.conf`
  - добавлен HTTP server на `80`;
  - `/.well-known/acme-challenge/` отдаётся из `/var/www/certbot`;
  - остальные HTTP-запросы редиректятся на HTTPS;
  - добавлен HTTPS server на `443` с сертификатами Let's Encrypt;
  - `/grafana/` проксируется в `grafana:3000`;
  - `/health/` проксируется в `health:8001`;
  - прокидываются `Host`, `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Proto`.

- `.env.example`
  - добавлен production domain `PUBLIC_DOMAIN=monitoring.probochka-corp.ru`;
  - `NGINX_PORT` переведён на `80`.

- `DEPLOYMENT.md`
  - добавлен runbook для первичного выпуска сертификата через Certbot;
  - описан переход renewal на webroot challenge;
  - добавлен deploy-hook для reload nginx после успешного renew;
  - добавлены smoke-check команды для HTTPS health и Grafana endpoints.

Зачем это сделано:

- чтобы Grafana и health endpoint были доступны через нормальный HTTPS endpoint;
- чтобы UptimeRobot мог проверять `https://monitoring.probochka-corp.ru/health/`;
- чтобы сертификаты оставались на сервере и не попадали в git, Docker image, логи или secrets.

Как это реализовано:

- Certbot остаётся host-managed;
- nginx-контейнер только читает сертификаты из `/etc/letsencrypt`;
- ACME webroot монтируется из `/var/www/certbot`;
- routine deploy остаётся через существующий Docker Compose/Ansible flow.

## Скриншоты / Демонстрация

N/A: изменения касаются production reverse-proxy, TLS и deployment-документации.

## Self-Check (Чек-лист качества)

### Базовые проверки

- [ ] Я провел ручное тестирование функциональности.
  - DNS проверен локально: `monitoring.probochka-corp.ru` резолвится в `31.163.204.186`.
  - Полный server-side smoke-check нужно выполнить после деплоя и выпуска сертификата.
- [ ] pre-commit хуки прошли успешно локально.
  - Отдельно не запускались; вместо этого выполнен `just quality-gate`.
- [x] Новые/измененные тесты проходят.
  - `just quality-gate`: `581 passed`.
- [x] Линтер ruff не выдает ошибок.
  - Проверено через `just quality-gate`.
- [x] Статический анализатор mypy (strict) не выдает ошибок.
  - N/A: проект использует `ty`; проверка прошла через `just quality-gate`.

### Архитектурный контроль (см. ARCHITECTURE.md)

- [x] Thin Handlers: в хендлерах бота нет бизнес-логики.
  - N/A: хендлеры не изменялись.
- [x] Rich Model: логика данных не размазана по сервису.
  - N/A: доменная модель и сервисы не изменялись.
- [x] Validation: входящие данные валидируются через Pydantic схемы.
  - N/A: DTO/validation не изменялись.
- [x] Type Hints: все новые функции и методы имеют аннотации типов.
  - N/A: Python-код не изменялся.
- [x] Docstrings: для публичных методов сервисов и репозиториев написаны Google-style докстринги.
  - N/A: сервисы и репозитории не изменялись.

### Работа с данными (если применимо)

- [x] Миграции БД (alembic revision) созданы и проверены.
  - N/A: схема БД не изменялась.
- [x] ВАЖНО: если добавлены новые таблицы, я проверил работу внешних ключей в SQLite.
  - N/A: таблицы не добавлялись.

## Особые пометки для ревьюера

Первичный сертификат должен быть выпущен на сервере до запуска финального TLS nginx-конфига, иначе nginx не стартует из-за отсутствующих файлов:

- `/etc/letsencrypt/live/monitoring.probochka-corp.ru/fullchain.pem`
- `/etc/letsencrypt/live/monitoring.probochka-corp.ru/privkey.pem`

Локально не удалось выполнить:

- `docker compose -f docker-compose.prod.yml config --quiet` — в окружении отсутствует Docker CLI.
- `just docs-build` — команда превысила таймаут примерно 304 секунды.

Дополнительно проверено:

- YAML `docker-compose.prod.yml` успешно парсится через PyYAML.
- `just quality-gate` прошёл успешно.